### PR TITLE
Update setup-java action to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '11'
         distribution: 'temurin'


### PR DESCRIPTION
Updated the `actions/setup-java` step in the CI workflow to version 5, per the user's request.